### PR TITLE
using graph.render instead of innerHTML=''

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -11,6 +11,12 @@ angular.module('d3chartsApp')
     ];
     $scope.renderer = 'line';
 
+    $scope.sightingsByDate = [{
+      x: 0,
+      y: 0,
+      y0: 0
+    }];
+
     $http.get('data/sightings.json').success(function(result) {
 
       var sightings = _(result)
@@ -25,8 +31,6 @@ angular.module('d3chartsApp')
           return sighting.sightedAt.getTime();
         })
         .value();
-
-
 
       $scope.sightingsByDate = _(sightings)
         .chain()

--- a/app/scripts/directives/rickshawChart.js
+++ b/app/scripts/directives/rickshawChart.js
@@ -3,6 +3,93 @@
 
 angular.module('d3chartsApp')
   .directive('rickshawChart', function() {
+    var graph;
+    var yAxis;
+    var xAxis;
+
+    /**
+     * Based on example of D3 in Angular
+     * https://github.com/3DGenomes/angular-d3js
+     */
+    var link = function postLink(scope, element, attrs) {
+      // execute properly within Angular scope life cycle
+      scope.safeApply = function(fn) {
+        var phase = this.$root.$$phase;
+        if (phase === '$apply' || phase === '$digest') {
+          if (fn && (typeof(fn) === 'function')) {
+            fn();
+          }
+        } else {
+          this.$apply(fn);
+        }
+      };
+
+      graph = graph || new Rickshaw.Graph({
+        element: element[0],
+        width: attrs.width,
+        height: attrs.height,
+        series: [{
+          data: scope.data,
+          color: attrs.color
+        }],
+        renderer: scope.renderer
+      });
+
+      yAxis = yAxis || new Rickshaw.Graph.Axis.Y({
+        graph: graph
+      });
+
+      xAxis = xAxis || new Rickshaw.Graph.Axis.Time({
+        graph: graph
+      });
+
+      var hover = hover || new Rickshaw.Graph.HoverDetail({
+        graph: graph,
+        formatter: function(series, x, y, formattedX, formattedY, /* jshint unused: vars */ d) {
+          return formattedY;
+        }
+      });
+
+      scope.render = function() {
+        scope.safeApply(function() {
+          yAxis.render();
+          xAxis.render();
+          graph.setRenderer(scope.renderer);
+          graph.series[0].data = scope.data || [{
+            x: 10,
+            y: 10
+          }];
+          graph.render();
+        });
+      };
+
+      scope.$watchCollection('[data, renderer]', function(newVal, /* jshint unused: vars */ oldVal) {
+        if (newVal[0] && scope.data === newVal[0]) {
+          scope.data = newVal[0];
+        }
+        if (newVal[1] && scope.renderer === newVal[1]) {
+          scope.renderer = newVal[1];
+        }
+        scope.render();
+      });
+
+      /* 
+       * component ie. directive === parentNode
+       */
+      var component = element[0].parentNode;
+      // render D3 chart on initialize and resize 
+      scope.$watch(function() {
+        var w = component.clientWidth;
+        var h = component.clientHeight;
+        return w + h;
+      }, function() {
+        graph.width = component.clientWidth;
+        graph.height = component.clientHeight;
+        scope.render();
+      });
+
+    };
+
     return {
       scope: {
         data: '=',
@@ -10,45 +97,6 @@ angular.module('d3chartsApp')
       },
       template: '<div></div>',
       restrict: 'E',
-      link: function postLink(scope, element, attrs) {
-        scope.$watchCollection('[data, renderer]', function(newVal, /* jshint unused: vars */ oldVal) {
-          if (!newVal[0]) {
-            return;
-          }
-          element[0].innerHTML = '';
-          var graph = new Rickshaw.Graph({
-            element: element[0],
-            width: attrs.width,
-            height: attrs.height,
-            series: [{
-              data: scope.data,
-              color: attrs.color
-            }],
-            renderer: scope.renderer
-          });
-
-
-          var yAxis = new Rickshaw.Graph.Axis.Y({
-            graph: graph
-          });
-          yAxis.render();
-
-
-          var xAxis = new Rickshaw.Graph.Axis.Time({
-            graph: graph
-          });
-          xAxis.render();
-
-          new Rickshaw.Graph.HoverDetail({
-            graph: graph,
-            formatter: function(series, x, y, formattedX, formattedY, /* jshint unused: vars */ d) {
-              return formattedY;
-            }
-          });
-
-          graph.render();
-
-        });
-      }
+      link: link
     };
   });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,8 @@ module.exports = function(config) {
       'app/bower_components/angular-cookies/angular-cookies.js',
       'app/bower_components/angular-sanitize/angular-sanitize.js',
       'app/bower_components/angular-route/angular-route.js',
+      'app/bower_components/rickshaw/vendor/d3.v2.js',
+      'app/bower_components/rickshaw/rickshaw.js',
       'app/scripts/*.js',
       'app/scripts/**/*.js',
       'test/mock/**/*.js',

--- a/test/spec/directives/rickshawChart.js
+++ b/test/spec/directives/rickshawChart.js
@@ -1,20 +1,72 @@
 'use strict';
 
-describe('Directive: rickshawChart', function () {
+var debugMode = true;
+describe('Directive: rickshawChart', function() {
 
   // load the directive's module
   beforeEach(module('d3chartsApp'));
 
-  var element,
-    scope;
+  describe('multiple charts', function() {
+    var element, scope, compileFunction;
 
-  beforeEach(inject(function ($rootScope) {
-    scope = $rootScope.$new();
-  }));
+    beforeEach(inject(function($rootScope, $compile) {
+      scope = $rootScope.$new();
+      scope.sightingsByDate = [{
+        x: 1199145600,
+        y: 39,
+        y0: 0
+      }, {
+        x: 1199232000,
+        y: 13,
+        y0: 0
+      }];
+      scope.sightingsByDate2 = [{
+        x: 1199145600,
+        y: 59,
+        y0: 0
+      }, {
+        x: 1199232000,
+        y: 30,
+        y0: 0
+      }];
+      scope.renderers = [
+        'line',
+        'bar',
+        'scatterplot',
+        'area'
+      ];
+      scope.renderer = 'line';
 
-  it('should make hidden element visible', inject(function ($compile) {
-    element = angular.element('<rickshaw-chart></rickshaw-chart>');
-    element = $compile(element)(scope);
-    expect(element.text()).toBe('');
-  }));
+      element = angular.element('<rickshaw-chart data="sightingsByDate" renderer="renderer" color="steelblue" width="700" height="450">' + 
+        '</rickshaw-chart><rickshaw-chart data="sightingsByDate2" renderer="renderer" color="steelblue" width="700" height="450"></rickshaw-chart>');
+      element = $compile(element)(scope);
+      
+      compileFunction = $compile(element);
+      if (debugMode) {
+        console.log('post compile', element.html()); // <== html here has {{}}
+      }
+    }));
+
+    it('should make a chart element with only contents from scope', function() {
+      inject(function() {
+        compileFunction(scope); // <== the html {{}} are bound
+         scope.$digest();
+        if (!scope.$$phase) {
+          scope.$digest(); // <== digest to get the render to show the bound values
+        }
+
+        if (debugMode) {
+          console.log('post link', element.html());
+          console.log('scope sightingsByDate ', scope.sightingsByDate);
+          console.log(angular.element());
+        }
+        expect(angular.element(element.find('div')[0]).text().trim()).toEqual('');
+        var svg = angular.element(element.find('svg'));
+        expect(svg.length).toEqual(0);
+        expect(angular.element(element.find('.detail')).length).toEqual(0);
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
I was working on a bug report that was tweeted at us and found that quite a few folks were basing their rickshaw angular integration on this example because it is so complete and comes with a great screencast.

It would be better if it showed how to customize the link function in an angular directive to use the rickshaw render `graph.render();` which just updates the svg, instead of emptying the dom `element[0].innerHTML = '';`. I know the diff is a bit hard to read because of the indentation change, but essentially this PR is based on the watcher and render set up in https://github.com/3DGenomes/angular-d3js. With this change I was also able to flesh out the tests a bit more.

Steps to reproduce

* grunt serve
* open http://localhost:9000
* change the renderer dropdown to a different renderer
* observe `Uncaught TypeError: Cannot read property 'getBoundingClientRect' of null`

```javascript
Uncaught TypeError: Cannot read property 'getBoundingClientRect' of null
rickshaw.js:2247
Rickshaw.Graph.HoverDetail.Rickshaw.Class.create._calcLayoutError
rickshaw.js:2247
Rickshaw.Graph.HoverDetail.Rickshaw.Class.create.render rickshaw.js:2222
Rickshaw.Graph.HoverDetail.Rickshaw.Class.create.update rickshaw.js:2138
```
<img width="1810" alt="screen shot 2017-07-26 at 6 53 29 am" src="https://user-images.githubusercontent.com/196199/28624873-6398846e-71cf-11e7-85e0-7a73c37fdbf1.png">


Emptying the dom in the directive works, but it orphans the event listeners which means that when the the hover detail looks for `this.element.parentNode` it errors because it doesn't exist anymore. 

```javascript
_calcLayoutError: function(alignables) {
		// Layout error is calculated as the number of linear pixels by which
		// an alignable extends past the left or right edge of the parent.
		var parentRect = this.element.parentNode.getBoundingClientRect();
```

More info in here: https://github.com/shutterstock/rickshaw/issues/432 